### PR TITLE
setup_requires makes pip failing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ click
 pyinotify
 keyring
 keyrings.alt
+pytest-runner

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
         "pyinotify",
         "keyring",
         "keyrings.alt",
+        "pytest-runner",
     ],
-    setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     zip_safe=True,
     entry_points={


### PR DESCRIPTION
setup_requires makes pip failing when using own devpi repository because it does honor PIP_INDEX_URL

Btw using setup_requires is now deprecated in setuptools itself
https://github.com/pypa/setuptools/issues/1320#issuecomment-380093653